### PR TITLE
Suppress fitsio dependency

### DIFF
--- a/ipy.c
+++ b/ipy.c
@@ -32,8 +32,6 @@
 #include <float.h>
 #include <limits.h>
 
-#include <fitsio.h>
-
 #include <pstdlib.h>
 #include <play.h>
 #include <yapi.h>


### PR DESCRIPTION
I suppose `#include <fitsio.h>` is useless. At least it can compile without.
 
what a PR ;-)